### PR TITLE
#fix broken pngcrush link

### DIFF
--- a/env/env-setup
+++ b/env/env-setup
@@ -20,7 +20,7 @@ cd ..
 # Pngcrush
 echo 'Installing of Pngcrush..'
 mkdir $ROOT/pngcrush && cd $_
-curl -L http://sourceforge.net/projects/pmt/files/pngcrush/1.7.85/pngcrush-1.7.85.tar.gz/download | tar xz --strip-components=1
+curl -L http://sourceforge.net/projects/pmt/files/pngcrush/old-versions/1.7/1.7.85/pngcrush-1.7.85.tar.gz/download | tar xz --strip-components=1
 make
 
 cd ..


### PR DESCRIPTION
Sourceforge changed the directory structure for `pngcrush` causing a break during `npm install imageoptim`.
